### PR TITLE
Fixed river segment label from breaking out of box on mobile

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -5,6 +5,10 @@ body {
   font-size: 17px;
 }
 
+.label {
+  display: inline-block;
+  white-space: normal;
+}
 .label:hover { text-decoration: none; }
 
 /* Everything but the jumbotron gets side spacing for mobile first views */


### PR DESCRIPTION
Before the fix:

![label-broken](https://cloud.githubusercontent.com/assets/76278/4636439/c2bddace-53e2-11e4-9291-29ce451e83c6.png)

After the fix:

![label-fixed](https://cloud.githubusercontent.com/assets/76278/4636442/c6420756-53e2-11e4-9bea-98e985658419.png)
