### PR TITLE
Fix link to mwrd notification signup

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -90,7 +90,7 @@
         The Metropolitan Water Reclamation District of Greater Chicago offers email and text message notifications for Combined Sewer Overflow events.
       </p>
 
-      <p><i class='fa fa-fw fa-mobile'></i> <a href='http://apps.mwrd.org/cso/bookC.aspx'>Sign up for MWRD's text and email alerts &raquo;</a></p>
+      <p><i class='fa fa-fw fa-mobile'></i> <a href='http://apps.mwrd.org/CSORegistration/Register'>Sign up for MWRD's text and email alerts &raquo;</a></p>
 
       <p><strong>Fair warning</strong>, if you sign up for these notifications, you will get text messages in the middle of the night.</p>
 


### PR DESCRIPTION
The old link 404s which makes this difficult to verify. However, this seems to be the new link for signing up for notifications.